### PR TITLE
Improve robustness of ping RTT parsing in collector service

### DIFF
--- a/jetson/collector_service/main.py
+++ b/jetson/collector_service/main.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 import platform
+import re
 import subprocess
 import sys
 import threading
@@ -336,15 +337,20 @@ class Pinger:
 
     @staticmethod
     def _parse_rtt_ms(output: str) -> Optional[float]:
-        for line in output.splitlines():
-            if "round-trip" in line or "rtt" in line or "Average =" in line:
-                numbers = [token for token in line.replace("=", "/").replace("ms", "").split("/") if token.strip()]
-                try:
-                    values = [float(value) for value in numbers]
-                except ValueError:
-                    continue
-                if values:
-                    return values[min(1, len(values) - 1)]
+        # Linux: rtt min/avg/max/mdev = 0.045/0.045/0.045/0.000 ms
+        # Windows: Minimum = 0ms, Maximum = 0ms, Average = 0ms
+        
+        # Try Linux format first (looking for avg)
+        # matches: rtt ... = .../.../avg/...
+        match = re.search(r"=\s*[0-9.]+/([0-9.]+)/", output)
+        if match:
+            return float(match.group(1))
+
+        # Windows format (Average = Xms)
+        match = re.search(r"Average\s*=\s*([0-9]+)ms", output)
+        if match:
+             return float(match.group(1))
+        
         return None
 
 

--- a/jetson/collector_service/main.py
+++ b/jetson/collector_service/main.py
@@ -337,20 +337,30 @@ class Pinger:
 
     @staticmethod
     def _parse_rtt_ms(output: str) -> Optional[float]:
-        # Linux: rtt min/avg/max/mdev = 0.045/0.045/0.045/0.000 ms
-        # Windows: Minimum = 0ms, Maximum = 0ms, Average = 0ms
+        # Linux / Mac / BSD: rtt min/avg/max/mdev = 13.425/13.425/13.425/0.000 ms
+        # BusyBox: round-trip min/avg/max = 13.425/13.425/13.425 ms
+        # We look for the pattern "... = min/avg/max..."
+        # The average is the second number.
         
-        # Try Linux format first (looking for avg)
-        # matches: rtt ... = .../.../avg/...
-        match = re.search(r"=\s*[0-9.]+/([0-9.]+)/", output)
+        # Regex for *nix style
+        # matches: ... = <num>/<num>/<num> ...
+        nix_pattern = re.compile(r"(?:rtt|round-trip)[^=]*=\s*([0-9\.]+)/([0-9\.]+)/([0-9\.]+)")
+        match = nix_pattern.search(output)
         if match:
-            return float(match.group(1))
+            try:
+                return float(match.group(2))
+            except ValueError:
+                pass
 
-        # Windows format (Average = Xms)
-        match = re.search(r"Average\s*=\s*([0-9]+)ms", output)
+        # Windows style: Average = 13ms
+        win_pattern = re.compile(r"Average\s*=\s*([0-9\.]+)")
+        match = win_pattern.search(output)
         if match:
-             return float(match.group(1))
-        
+            try:
+                return float(match.group(1))
+            except ValueError:
+                pass
+                
         return None
 
 

--- a/tests/test_collector_service.py
+++ b/tests/test_collector_service.py
@@ -79,5 +79,65 @@ class CollectorServiceTest(unittest.IsolatedAsyncioTestCase):
         return tmp.name
 
 
+class PingParsingTest(unittest.TestCase):
+    def test_linux_iputils(self):
+        from jetson.collector_service.main import Pinger
+        output = """
+PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+64 bytes from 8.8.8.8: icmp_seq=1 ttl=115 time=13.4 ms
+
+--- 8.8.8.8 ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time 0ms
+rtt min/avg/max/mdev = 13.425/13.425/13.425/0.000 ms
+"""
+        self.assertAlmostEqual(Pinger._parse_rtt_ms(output), 13.425)
+
+    def test_linux_busybox(self):
+        from jetson.collector_service.main import Pinger
+        output = """
+PING 8.8.8.8 (8.8.8.8): 56 data bytes
+64 bytes from 8.8.8.8: seq=0 ttl=115 time=13.4 ms
+
+--- 8.8.8.8 ping statistics ---
+1 packets transmitted, 1 packets received, 0% packet loss
+round-trip min/avg/max = 13.425/13.425/13.425 ms
+"""
+        self.assertAlmostEqual(Pinger._parse_rtt_ms(output), 13.425)
+
+    def test_windows(self):
+        from jetson.collector_service.main import Pinger
+        output = """
+Pinging 8.8.8.8 with 32 bytes of data:
+Reply from 8.8.8.8: bytes=32 time=13ms TTL=115
+
+Ping statistics for 8.8.8.8:
+    Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),
+Approximate round trip times in milli-seconds:
+    Minimum = 13ms, Maximum = 13ms, Average = 13ms
+"""
+        self.assertEqual(Pinger._parse_rtt_ms(output), 13.0)
+
+    def test_mac_bsd(self):
+        from jetson.collector_service.main import Pinger
+        output = """
+PING 8.8.8.8 (8.8.8.8): 56 data bytes
+64 bytes from 8.8.8.8: icmp_seq=0 ttl=115 time=13.425 ms
+
+--- 8.8.8.8 ping statistics ---
+1 packets transmitted, 1 packets received, 0.0% packet loss
+round-trip min/avg/max/stddev = 13.425/13.425/13.425/0.000 ms
+"""
+        self.assertAlmostEqual(Pinger._parse_rtt_ms(output), 13.425)
+
+    def test_no_output(self):
+        from jetson.collector_service.main import Pinger
+        self.assertIsNone(Pinger._parse_rtt_ms(""))
+
+    def test_partial_output(self):
+        from jetson.collector_service.main import Pinger
+        output = "PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data."
+        self.assertIsNone(Pinger._parse_rtt_ms(output))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_collector_service.py
+++ b/tests/test_collector_service.py
@@ -79,65 +79,6 @@ class CollectorServiceTest(unittest.IsolatedAsyncioTestCase):
         return tmp.name
 
 
-class PingParsingTest(unittest.TestCase):
-    def test_linux_iputils(self):
-        from jetson.collector_service.main import Pinger
-        output = """
-PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
-64 bytes from 8.8.8.8: icmp_seq=1 ttl=115 time=13.4 ms
-
---- 8.8.8.8 ping statistics ---
-1 packets transmitted, 1 received, 0% packet loss, time 0ms
-rtt min/avg/max/mdev = 13.425/13.425/13.425/0.000 ms
-"""
-        self.assertAlmostEqual(Pinger._parse_rtt_ms(output), 13.425)
-
-    def test_linux_busybox(self):
-        from jetson.collector_service.main import Pinger
-        output = """
-PING 8.8.8.8 (8.8.8.8): 56 data bytes
-64 bytes from 8.8.8.8: seq=0 ttl=115 time=13.4 ms
-
---- 8.8.8.8 ping statistics ---
-1 packets transmitted, 1 packets received, 0% packet loss
-round-trip min/avg/max = 13.425/13.425/13.425 ms
-"""
-        self.assertAlmostEqual(Pinger._parse_rtt_ms(output), 13.425)
-
-    def test_windows(self):
-        from jetson.collector_service.main import Pinger
-        output = """
-Pinging 8.8.8.8 with 32 bytes of data:
-Reply from 8.8.8.8: bytes=32 time=13ms TTL=115
-
-Ping statistics for 8.8.8.8:
-    Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),
-Approximate round trip times in milli-seconds:
-    Minimum = 13ms, Maximum = 13ms, Average = 13ms
-"""
-        self.assertEqual(Pinger._parse_rtt_ms(output), 13.0)
-
-    def test_mac_bsd(self):
-        from jetson.collector_service.main import Pinger
-        output = """
-PING 8.8.8.8 (8.8.8.8): 56 data bytes
-64 bytes from 8.8.8.8: icmp_seq=0 ttl=115 time=13.425 ms
-
---- 8.8.8.8 ping statistics ---
-1 packets transmitted, 1 packets received, 0.0% packet loss
-round-trip min/avg/max/stddev = 13.425/13.425/13.425/0.000 ms
-"""
-        self.assertAlmostEqual(Pinger._parse_rtt_ms(output), 13.425)
-
-    def test_no_output(self):
-        from jetson.collector_service.main import Pinger
-        self.assertIsNone(Pinger._parse_rtt_ms(""))
-
-    def test_partial_output(self):
-        from jetson.collector_service.main import Pinger
-        output = "PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data."
-        self.assertIsNone(Pinger._parse_rtt_ms(output))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pinger.py
+++ b/tests/test_pinger.py
@@ -26,5 +26,38 @@ Approximate round trip times in milli-seconds:
         rtt = Pinger._parse_rtt_ms(output)
         self.assertIsNone(rtt)
 
+    def test_linux_iputils_full(self):
+        output = """
+PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+64 bytes from 8.8.8.8: icmp_seq=1 ttl=115 time=13.4 ms
+
+--- 8.8.8.8 ping statistics ---
+1 packets transmitted, 1 received, 0% packet loss, time 0ms
+rtt min/avg/max/mdev = 13.425/13.425/13.425/0.000 ms
+"""
+        self.assertAlmostEqual(Pinger._parse_rtt_ms(output), 13.425)
+
+    def test_linux_busybox(self):
+        output = """
+PING 8.8.8.8 (8.8.8.8): 56 data bytes
+64 bytes from 8.8.8.8: seq=0 ttl=115 time=13.4 ms
+
+--- 8.8.8.8 ping statistics ---
+1 packets transmitted, 1 packets received, 0% packet loss
+round-trip min/avg/max = 13.425/13.425/13.425 ms
+"""
+        self.assertAlmostEqual(Pinger._parse_rtt_ms(output), 13.425)
+
+    def test_mac_bsd(self):
+        output = """
+PING 8.8.8.8 (8.8.8.8): 56 data bytes
+64 bytes from 8.8.8.8: icmp_seq=0 ttl=115 time=13.425 ms
+
+--- 8.8.8.8 ping statistics ---
+1 packets transmitted, 1 packets received, 0.0% packet loss
+round-trip min/avg/max/stddev = 13.425/13.425/13.425/0.000 ms
+"""
+        self.assertAlmostEqual(Pinger._parse_rtt_ms(output), 13.425)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pinger.py
+++ b/tests/test_pinger.py
@@ -1,0 +1,30 @@
+import unittest
+from jetson.collector_service.main import Pinger, PingConfig
+
+class TestPinger(unittest.TestCase):
+    def test_parse_rtt_linux(self):
+        output = "rtt min/avg/max/mdev = 0.045/0.055/0.065/0.000 ms"
+        rtt = Pinger._parse_rtt_ms(output)
+        self.assertEqual(rtt, 0.055)
+
+    def test_parse_rtt_windows(self):
+        output = """
+Pinging 1.1.1.1 with 32 bytes of data:
+Reply from 1.1.1.1: bytes=32 time=2ms TTL=50
+Reply from 1.1.1.1: bytes=32 time=2ms TTL=50
+
+Ping statistics for 1.1.1.1:
+    Packets: Sent = 2, Received = 2, Lost = 0 (0% loss),
+Approximate round trip times in milli-seconds:
+    Minimum = 2ms, Maximum = 2ms, Average = 2ms
+"""
+        rtt = Pinger._parse_rtt_ms(output)
+        self.assertEqual(rtt, 2.0)
+
+    def test_parse_rtt_invalid(self):
+        output = "PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data."
+        rtt = Pinger._parse_rtt_ms(output)
+        self.assertIsNone(rtt)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Replaced fragile string splitting with regex-based parsing to handle different ping output formats (Linux/Windows) more reliably. Added new unit tests in `tests/test_pinger.py` to verify the parsing logic.

Fixes #43