### PR TITLE
Github code review and fix

### DIFF
--- a/jetson/ml_service/main.py
+++ b/jetson/ml_service/main.py
@@ -812,10 +812,13 @@ class MlService:
             except json.JSONDecodeError as exc:
                 logging.error("Invalid JSON in %s: %s", path, exc)
                 return None
-            entries = data.get("entries") if isinstance(data, dict) else data
-            if not isinstance(entries, list):
+            
+            raw_entries = data.get("entries") if isinstance(data, dict) else data
+            if not isinstance(raw_entries, list):
                 logging.error("history file is not a list")
                 return None
+            
+            entries = raw_entries  # type: ignore [assignment]
             self._history_cache = entries
             self._history_mtime = mtime
             logging.debug("Loaded %d entries from history (mtime: %f)", len(entries), mtime)

--- a/jetson/ml_service/main.py
+++ b/jetson/ml_service/main.py
@@ -709,6 +709,8 @@ class MlService:
             model_path=config.model_path,
             metadata_path=config.model_metadata_path,
         )
+        self._history_cache: List[Dict[str, Any]] | None = None
+        self._history_mtime: float = 0.0
 
     def request_stop(self, *_: Any) -> None:
         logging.info("Stop requested; finishing current cycle")
@@ -796,15 +798,28 @@ class MlService:
         path = self._config.history_path
         if not path.exists():
             return None
+
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            logging.error("Invalid JSON in %s: %s", path, exc)
+            mtime = path.stat().st_mtime
+        except OSError:
             return None
-        entries = data.get("entries") if isinstance(data, dict) else data
-        if not isinstance(entries, list):
-            logging.error("history file is not a list")
-            return None
+
+        if self._history_cache is not None and mtime == self._history_mtime:
+            entries = self._history_cache
+        else:
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                logging.error("Invalid JSON in %s: %s", path, exc)
+                return None
+            entries = data.get("entries") if isinstance(data, dict) else data
+            if not isinstance(entries, list):
+                logging.error("history file is not a list")
+                return None
+            self._history_cache = entries
+            self._history_mtime = mtime
+            logging.debug("Loaded %d entries from history (mtime: %f)", len(entries), mtime)
+
         recent_cutoff = time.time() - self._config.history_window_seconds
         filtered = [entry for entry in entries if entry.get("timestamp", 0) >= recent_cutoff]
         return filtered or entries


### PR DESCRIPTION
Implement `mtime`-based caching for `_load_history` to reduce I/O and CPU usage.

The `ml_service` polls the `history.json` file every 5 seconds, while the `state_engine_service` typically updates it every 60 seconds. This change avoids approximately 11 unnecessary file re-reads and JSON parsing operations per minute by reusing the in-memory history list if the file's modification time has not changed.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3e273d6-db78-4d40-a053-3071f134866b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3e273d6-db78-4d40-a053-3071f134866b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

