### PR TITLE
Github code review and fix

### DIFF
--- a/jetson/requirements.txt
+++ b/jetson/requirements.txt
@@ -8,3 +8,4 @@ jsonschema>=4.21
 aiohttp>=3.9
 pydantic>=2.0
 httpx>=0.28.0
+python-dotenv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,7 @@
--r jetson/requirements.txt
--r epaper/requirements.txt
+-r requirements.txt
 ruff==0.7.1
 mypy==1.13.0
 types-PyYAML==6.0.12.20240917
 types-requests==2.32.0.20241016
 httpx>=0.28.0
 colorama==0.4.6
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-r jetson/requirements.txt
+-r epaper/requirements.txt


### PR DESCRIPTION
Add `python-dotenv` to `jetson` requirements and consolidate project dependencies into a root `requirements.txt` to fix test runner failures.

The root test runner failed due to a `ModuleNotFoundError` for `python-dotenv` in `jetson` code. This PR addresses that by adding the missing dependency and also introduces a consolidated root `requirements.txt` to simplify environment setup and keep dependency management DRY.

---
<a href="https://cursor.com/background-agent?bcId=bc-926518aa-4316-4530-a922-c086c0fb567b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-926518aa-4316-4530-a922-c086c0fb567b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

